### PR TITLE
new(git-repos): accept new host keys when fetching git repos

### DIFF
--- a/ansible-playbooks/roles/git_repos/tasks/main.yml
+++ b/ansible-playbooks/roles/git_repos/tasks/main.yml
@@ -7,6 +7,7 @@
     version: "{{ item.value.version | default(omit) }}"
     refspec: "{{ item.value.refspec | default(omit) }}"
     dest: "{{ local_repos_folder }}/{{ item.value.name | mandatory }}"
+    accept_newhostkey: true
   with_dict: "{{ repos }}"
   delegate_to: localhost
   run_once: true


### PR DESCRIPTION
The git module will only accept host keys that are not present or are the same as existing ones.