### PR TITLE
feat(scap-open): check btf support using scap-open

### DIFF
--- a/ansible-playbooks/group_vars/all/vars.yml
+++ b/ansible-playbooks/group_vars/all/vars.yml
@@ -22,7 +22,6 @@ machines:
   - {name: "amazonlinux2-5.10", kernel: "therealbobo/amazonlinux2-kernel:5.10-x86_64", rootfs: "therealbobo/amazonlinux2-image:5.10-x86_64", arch: "x86_64"}
   - {name: "amazonlinux2-5.15", kernel: "therealbobo/amazonlinux2-kernel:5.15-x86_64", rootfs: "therealbobo/amazonlinux2-image:5.15-x86_64", arch: "x86_64"}
   - {name: "amazonlinux2-5.4", kernel: "therealbobo/amazonlinux2-kernel:5.4-x86_64", rootfs: "therealbobo/amazonlinux2-image:5.4-x86_64", arch: "x86_64"}
-  - {name: "archlinux-5.18", kernel: "therealbobo/archlinux-kernel:5.18-x86_64", rootfs: "therealbobo/archlinux-image:5.18-x86_64", arch: "x86_64"}
   - {name: "archlinux-6.0", kernel: "therealbobo/archlinux-kernel:6.0-x86_64", rootfs: "therealbobo/archlinux-image:6.0-x86_64", arch: "x86_64"}
   - {name: "centos-3.10", kernel: "therealbobo/centos-kernel:3.10-x86_64", rootfs: "therealbobo/centos-image:3.10-x86_64", arch: "x86_64"}
   - {name: "centos-4.18", kernel: "therealbobo/centos-kernel:4.18-x86_64", rootfs: "therealbobo/centos-image:4.18-x86_64", arch: "x86_64"}

--- a/ansible-playbooks/roles/scap_open/tasks/main.yml
+++ b/ansible-playbooks/roles/scap_open/tasks/main.yml
@@ -16,33 +16,16 @@
 
 - name: Check Modern Bpf Support
   block:
-    - name: Check BTF support
-      ansible.builtin.stat:
-        path: /sys/kernel/btf/vmlinux
-      register: btf_support
-
-    - name: Look up for BPF_MAP_TYPE_RINGBUF
-      ansible.builtin.lineinfile:
-        path: /usr/include/linux/bpf.h
-        regex: BPF_MAP_TYPE_RINGBUF*
-        state: absent
+    - name: Check modern-bpf support
+      ansible.builtin.command:
+        cmd: /tmp/scap-open --num_events 0 --modern_bpf
+      register: result
       changed_when: false
-      check_mode: 'yes'
-      register: ringbuf_present
-
-    - name: Look up for BPF_PROG_TYPE_TRACING
-      ansible.builtin.lineinfile:
-        path: /usr/include/linux/bpf.h
-        regex: BPF_PROG_TYPE_TRACING*
-        state: absent
-      changed_when: false
-      check_mode: 'yes'
-      register: tracing_present
-
+  rescue:
     - name: Enable Modern Bpf support
       ansible.builtin.set_fact:
         modern_bpf_supported: true
-      when: btf_support.stat.exists and ringbuf_present.found and tracing_present.found
+      when: result.rc != 95
 
 - name: Check Old Bpf Support
   block:


### PR DESCRIPTION
The `scap-open` binary is used to check if a given distro supports the `modern bpf probe`. 