### PR TITLE
fix(scap-open): do not skip modern bpf probe on supported platforms

### DIFF
--- a/ansible-playbooks/roles/scap_open/tasks/main.yml
+++ b/ansible-playbooks/roles/scap_open/tasks/main.yml
@@ -22,10 +22,10 @@
       register: result
       changed_when: false
   rescue:
-    - name: Enable Modern Bpf support
+    - name: Disable Modern Bpf support
       ansible.builtin.set_fact:
-        modern_bpf_supported: true
-      when: result.rc != 95
+        modern_bpf_supported: false
+      when: result.rc == 95
 
 - name: Check Old Bpf Support
   block:

--- a/ansible-playbooks/roles/scap_open/vars/main.yml
+++ b/ansible-playbooks/roles/scap_open/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-modern_bpf_supported: false
+modern_bpf_supported: true
 bpf_supported: false
 bpf_minimum_kver:
   aarch64: '4.17'


### PR DESCRIPTION
Only disable bpf modern probe when not supported by the distro.