### PR TITLE
new(images): added an ubuntu 5.8-aws clang-7 image.

### DIFF
--- a/ansible-playbooks/group_vars/all/vars.yml
+++ b/ansible-playbooks/group_vars/all/vars.yml
@@ -41,6 +41,7 @@ machines:
   - {name: "oraclelinux-5.15", kernel: "{{ repo }}/oraclelinux-kernel:5.15-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.15-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "oraclelinux-5.4", kernel: "{{ repo }}/oraclelinux-kernel:5.4-x86_64-{{ tag }}", rootfs: "{{ repo }}/oraclelinux-image:5.4-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "ubuntu-4.15", kernel: "{{ repo }}/ubuntu-kernel:4.15-x86_64-{{ tag }}", rootfs: "{{ repo }}/ubuntu-image:4.15-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
+  - {name: "ubuntu-5.8", kernel: "{{ repo }}/ubuntu-kernel:5.8-x86_64-{{ tag }}", rootfs: "{{ repo }}/ubuntu-image:5.8-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "ubuntu-6.5", kernel: "{{ repo }}/ubuntu-kernel:6.5-x86_64-{{ tag }}", rootfs: "{{ repo }}/ubuntu-image:6.5-x86_64-{{ tag }}", arch: "x86_64"} # noqa: yaml[line-length]
   - {name: "amazonlinux2022-5.15", kernel: "{{ repo }}/amazonlinux2022-kernel:5.15-aarch64-{{ tag }}", rootfs: "{{ repo }}/amazonlinux2022-image:5.15-aarch64-{{ tag }}", arch: "aarch64"}  # noqa: yaml[line-length]
   - {name: "amazonlinux2-5.4", kernel: "{{ repo }}/amazonlinux2-kernel:5.4-aarch64-{{ tag }}", rootfs: "{{ repo }}/amazonlinux2-image:5.4-aarch64-{{ tag }}", arch: "aarch64"} # noqa: yaml[line-length]

--- a/images/x86_64/ubuntu/5.8/Dockerfile
+++ b/images/x86_64/ubuntu/5.8/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04
+
+ARG VERSION=5.8.0-1041-aws
+
+WORKDIR /home/ubuntu
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		build-essential \
+		clang-7 \
+		cmake \
+		curl \
+		dbus \
+		git \
+		iproute2 \
+		iputils-ping \
+		kmod \
+		libcap-dev \
+		libelf-dev \
+		linux-headers-${VERSION} \
+		linux-tools-${VERSION} \
+		llvm \
+		net-tools \
+		openssh-server \
+		rng-tools \
+		rsync \
+		sudo \
+		systemd \
+		udev \
+		wget && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* && \
+	echo "" > /etc/machine-id && echo "" > /var/lib/dbus/machine-id && \
+	sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config && \
+	echo 'UseDNS no' >> /etc/ssh/sshd_config && \
+	echo "root:root" | chpasswd && \
+	ln -s /usr/bin/clang-7 /usr/bin/clang

--- a/images/x86_64/ubuntu/5.8/Dockerfile.kernel
+++ b/images/x86_64/ubuntu/5.8/Dockerfile.kernel
@@ -1,0 +1,24 @@
+FROM initrd-builder:0.0.1 AS builder
+
+ARG VERSION=5.8.0-1041-aws
+ARG URL='http://security.ubuntu.com/ubuntu/pool/main/l/linux-aws-5.8/'
+
+WORKDIR /home/ubuntu
+
+RUN touch .placeholder && \
+		curl ${URL} | \
+		grep -E "linux-image-${VERSION}|linux-modules-${VERSION}" | \
+		cut -d\" -f8 | \
+		xargs -I@ curl -LO ${URL}@ && \
+	mkdir extracted && \
+	ls *deb | \
+		xargs -I@ dpkg -x @ extracted && \
+	extract-vmlinux extracted/boot/vmlinuz-${VERSION} > extracted/vmlinux && \
+	cd extracted && \
+	/opt/initrd-builder/create.sh
+
+FROM scratch
+
+COPY --from=builder /home/ubuntu/extracted/vmlinux /boot/
+COPY --from=builder /home/ubuntu//out/initrd /boot/
+COPY --from=builder /home/ubuntu/.placeholder /lib/modules/


### PR DESCRIPTION
This image will allow us to drop CircleCI from libs since this is exactly the same machine used in that tests: https://github.com/falcosecurity/libs/blob/master/.circleci/config.yml#L3
The kernel version used was taken by https://app.circleci.com/pipelines/github/falcosecurity/libs/3254/workflows/bb2271b4-89ac-4a73-99b2-39b3e9b8f786/jobs/8623.