### PR TITLE
fix(images): fixed ubuntu-6.5 base image 

### DIFF
--- a/images/aarch64/ubuntu/6.5/Dockerfile
+++ b/images/aarch64/ubuntu/6.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:23.10
 
 ARG VERSION=6.5.0-17
 ARG URL='http://ports.ubuntu.com/ubuntu-ports/pool/main/l/linux/'

--- a/images/x86_64/ubuntu/6.5/Dockerfile
+++ b/images/x86_64/ubuntu/6.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:23.10
 
 ARG VERSION=6.5.0-17
 ARG URL='http://mirrors.edge.kernel.org/ubuntu/pool/main/l/linux/'


### PR DESCRIPTION
Old bpf probe build needs glibc 2.38 shipped by ubuntu 23.10.